### PR TITLE
Change FlowLogConstants proto enum name to a different one.

### DIFF
--- a/iotcore-logger/iotcore-logger-definition/src/main/proto/flow/FlowLogConstants.proto
+++ b/iotcore-logger/iotcore-logger-definition/src/main/proto/flow/FlowLogConstants.proto
@@ -33,7 +33,7 @@ enum LogCode {
   FL_900 = 900;  // Flow interval error
 }
 
-enum LogDetailKey {
+enum EntryDetailKey {
   // Previously defined
 
   device_key = 0;

--- a/iotcore-logger/iotcore-logger-standalone/src/main/java/com/baidu/iot/logger/standalone/Main.java
+++ b/iotcore-logger/iotcore-logger-standalone/src/main/java/com/baidu/iot/logger/standalone/Main.java
@@ -3,6 +3,7 @@
 
 package com.baidu.iot.logger.standalone;
 
+import com.baidu.iot.type.flow.constants.EntryDetailKey;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.observers.DisposableObserver;
 
@@ -111,8 +112,8 @@ public class Main {
                 function = i -> LogDetailKey.forNumber(i) != null
                         ? LogDetailKey.forNumber(i).name() : String.valueOf(i);
             } else if (logEntry.getCode().startsWith("FL")){
-                function = i -> com.baidu.iot.type.flow.constants.LogDetailKey.forNumber(i) != null
-                    ? LogDetailKey.forNumber(i).name() : String.valueOf(i);
+                function = i -> EntryDetailKey.forNumber(i) != null
+                    ? EntryDetailKey.forNumber(i).name() : String.valueOf(i);
             } else {
                 function = String::valueOf;
             }


### PR DESCRIPTION
# Description

Change FlowLogConstants proto enum name to a different one to distinguish with MQTTLogConstants.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../eng/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
